### PR TITLE
Add Dependabot config based on Target standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       day: "sunday"
       time: "00:00"
       timezone: "Asia/Kolkata"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "direct"
 
@@ -23,6 +25,8 @@ updates:
       day: "sunday"
       time: "00:00"
       timezone: "Asia/Kolkata"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "direct"
 
@@ -33,5 +37,7 @@ updates:
       day: "sunday"
       time: "00:00"
       timezone: "Asia/Kolkata"
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
This configuration sets up Dependabot to check for updates to direct dependencies for Docker, GitHub Actions, and Python packages on a weekly basis every Sunday at midnight in the Asia/Kolkata timezone.

Extracted from https://github.com/target/.github/blob/main/dependabot.yml