### PR TITLE
Dogfood main branch in PR tests

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -47,4 +47,5 @@ jobs:
         with:
           persist-credentials: false
       - name: Diff poetry.lock
-        uses: target/diff-poetry-lock@main
+        uses: | # zizmor: ignore[unpinned-uses] It's safe to use main on our own repo.
+          target/diff-poetry-lock@main


### PR DESCRIPTION
I realized when reading #21 that this repo doesn't actually use system itself. Let's use it from main instead of a release branch, and I'll open a ticket to allow changing the magic header so that we can inject something into it and have _multiple_ comments posted.

Zizmor should throw a warning on using main, I'll have to find the way to silence it.