### PR TITLE
Handled duplicate diff comments

### DIFF
--- a/diff_poetry_lock/github.py
+++ b/diff_poetry_lock/github.py
@@ -5,8 +5,7 @@ from requests import Response
 
 from diff_poetry_lock.settings import PrLookupConfigurable, Settings
 
-MAGIC_COMMENT_IDENTIFIER = "<!-- posted by Github Action nborrmann/diff-poetry-lock -->\n\n"
-MAGIC_BOT_USER_ID = 41898282
+MAGIC_COMMENT_IDENTIFIER = "<!-- posted by target/diff-poetry-lock -->\n\n"
 
 
 class GithubComment(BaseModel):
@@ -17,8 +16,8 @@ class GithubComment(BaseModel):
     id_: int = Field(alias="id")
     user: GithubUser
 
-    def is_bot_comment(self) -> bool:
-        return self.body.startswith(MAGIC_COMMENT_IDENTIFIER) and self.user.id_ == MAGIC_BOT_USER_ID
+    def is_diff_comment(self) -> bool:
+        return self.body.startswith(MAGIC_COMMENT_IDENTIFIER)
 
 
 class RepoFileRetrievalError(BaseException):
@@ -83,7 +82,7 @@ class GithubApi:
             all_comments.extend(comments)
             page += 1
         logger.debug("Found %d comments", len(all_comments))
-        return [c for c in all_comments if c.is_bot_comment()]
+        return [c for c in all_comments if c.is_diff_comment()]
 
     def get_file(self, ref: str) -> Response:
         logger.debug("Fetching {} from ref {}", self.s.lockfile_path, ref)

--- a/diff_poetry_lock/test/test_poetry_diff.py
+++ b/diff_poetry_lock/test/test_poetry_diff.py
@@ -166,7 +166,6 @@ def test_e2e_no_diff_existing_comment(cfg: Settings, data1: bytes) -> None:
         comments = [
             {"body": "foobar", "id": 1334, "user": {"id": 123}},
             {"body": "foobar", "id": 1335, "user": {"id": 41898282}},
-            {"body": f"{MAGIC_COMMENT_IDENTIFIER}", "id": 1336, "user": {"id": 123}},
             {"body": f"{MAGIC_COMMENT_IDENTIFIER}foobar", "id": 1337, "user": {"id": 41898282}},
         ]
         mock_list_comments(m, cfg, comments)
@@ -212,7 +211,6 @@ def test_e2e_diff_existing_comment_same_data(cfg: Settings, data1: bytes, data2:
         comments = [
             {"body": "foobar", "id": 1334, "user": {"id": 123}},
             {"body": "foobar", "id": 1335, "user": {"id": 41898282}},
-            {"body": f"{MAGIC_COMMENT_IDENTIFIER}", "id": 1336, "user": {"id": 123}},
             {"body": f"{MAGIC_COMMENT_IDENTIFIER}{summary}", "id": 1337, "user": {"id": 41898282}},
         ]
         mock_list_comments(m, cfg, comments)
@@ -229,7 +227,6 @@ def test_e2e_diff_existing_comment_different_data(cfg: Settings, data1: bytes, d
         comments = [
             {"body": "foobar", "id": 1334, "user": {"id": 123}},
             {"body": "foobar", "id": 1335, "user": {"id": 41898282}},
-            {"body": f"{MAGIC_COMMENT_IDENTIFIER}", "id": 1336, "user": {"id": 123}},
             {"body": f"{MAGIC_COMMENT_IDENTIFIER}{summary}", "id": 1337, "user": {"id": 41898282}},
         ]
         mock_list_comments(m, cfg, comments)


### PR DESCRIPTION
Initially this was specific to github-actions bot comments
Now the bot identifier has been removed in the dup check and the marker identifier is alone used in dup check so that it is more generic and is reusable for both github-actions bot comments and comments made in vela pipeline
This addresses https://github.com/target/diff-poetry-lock/issues/17