### PR TITLE
Validate: add input validation for Poetry version format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 if [[ -n "${INPUT_POETRY_VERSION:-}" ]]; then
+	if [[ ! "${INPUT_POETRY_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		echo "Invalid Poetry version: ${INPUT_POETRY_VERSION}. Expected format X.Y.Z." >&2
+		exit 1
+	fi
 	echo "Installing Poetry ${INPUT_POETRY_VERSION} into isolated venv"
 	VENV_DIR=$(mktemp -d /tmp/poetry-venv.XXXX)
 	python3 -m venv "$VENV_DIR"


### PR DESCRIPTION
## Description

- Added strict validation for INPUT_POETRY_VERSION in entrypoint.sh

- Ensures the version matches ^[0-9]+\.[0-9]+\.[0-9]+$

- Rejects invalid values with an error message and exits before attempting Poetry install

Fixes #69 