### PR TITLE
Fix pr num lookup and a couple of other minor issues

### DIFF
--- a/diff_poetry_lock/github.py
+++ b/diff_poetry_lock/github.py
@@ -10,7 +10,7 @@ from github.Repository import Repository
 from loguru import logger
 from requests import Response
 
-from diff_poetry_lock.settings import PrLookupConfigurable, Settings
+from diff_poetry_lock.settings import Settings
 from diff_poetry_lock.utils import get_nested
 
 MAGIC_COMMENT_IDENTIFIER = "<!-- posted by target/diff-poetry-lock -->\n\n"
@@ -31,8 +31,6 @@ class GithubApi:
         self.requester = self.github.requester
         self._ref_hash_cache: dict[str, str] = {}
 
-        if isinstance(self.s, PrLookupConfigurable):
-            self.s.set_pr_lookup_service(self)
 
     @property
     def repo(self) -> Repository:

--- a/diff_poetry_lock/github_api.py
+++ b/diff_poetry_lock/github_api.py
@@ -102,7 +102,7 @@ class GithubApi:
         r = self.session.get(
             f"{self.s.api_url}/repos/{self.s.repository}/contents/{self.s.lockfile_path}",
             params={"ref": ref},
-            headers={"Authorization": self.s.token, "Accept": "application/vnd.github.raw"},
+            headers=self.Headers.RAW.headers(self.s.token),
             timeout=10,
             stream=True,
         )

--- a/diff_poetry_lock/github_api.py
+++ b/diff_poetry_lock/github_api.py
@@ -31,7 +31,6 @@ class GithubApi:
         self.requester = self.github.requester
         self._ref_hash_cache: dict[str, str] = {}
 
-
     @property
     def repo(self) -> Repository:
         if self._repo is None:
@@ -113,46 +112,51 @@ class GithubApi:
         r.raise_for_status()
         return r
 
-    def resolve_commit_hashes(self, head_ref: str, base_ref: str) -> tuple[str, str]:
-        cached_head_hash = self._ref_hash_cache.get(head_ref)
-        cached_base_hash = self._ref_hash_cache.get(base_ref)
+    def resolve_commit_hashes(self) -> tuple[str, str]:
+        cached_head_hash = self._ref_hash_cache.get(self.s.head_ref)
+        cached_base_hash = self._ref_hash_cache.get(self.s.base_ref)
         if cached_head_hash and cached_base_hash:
-            logger.debug("Using cached commit hashes for head_ref {} and base_ref {}", head_ref, base_ref)
+            logger.debug("Using cached commit hashes for head_ref {} and base_ref {}", self.s.head_ref, self.s.base_ref)
             return cached_head_hash, cached_base_hash
+
+        if not self.s.pr_num:
+            logger.warning("No PR number available; skipping commit hash resolution")
+            return self.s.head_ref, self.s.base_ref
 
         owner, repo_name = self.s.repository.split("/", maxsplit=1)
         query = (
-            "query($owner:String!, $name:String!, $head:String!, $base:String!){"
+            "query($owner:String!, $name:String!, $number:Int!){"
             " repository(owner:$owner, name:$name){"
-            "  head:ref(qualifiedName:$head){ target { ... on Commit { oid } } }"
-            "  base:ref(qualifiedName:$base){ target { ... on Commit { oid } } }"
+            "  pullRequest(number:$number) { headRefOid baseRefOid }"
             " }"
             "}"
         )
         variables = {
             "owner": owner,
             "name": repo_name,
-            "head": self._qualified_ref(head_ref),
-            "base": self._qualified_ref(base_ref),
+            "number": self.s.pr_num,
         }
 
         try:
             _, response_json = self.requester.graphql_query(query, variables)
 
             repo_data = response_json.get("data", {}).get("repository", {})
-            resolved_head_hash = str(get_nested(repo_data, ("head", "target", "oid")) or "").strip()
-            resolved_base_hash = str(get_nested(repo_data, ("base", "target", "oid")) or "").strip()
+
+            resolved_head_hash = str(get_nested(repo_data, ("pullRequest", "headRefOid")) or "").strip()
+
+            resolved_base_hash = str(get_nested(repo_data, ("pullRequest", "baseRefOid")) or "").strip()
+
             if resolved_head_hash:
-                self._ref_hash_cache[head_ref] = resolved_head_hash
+                self._ref_hash_cache[self.s.head_ref] = resolved_head_hash
             if resolved_base_hash:
-                self._ref_hash_cache[base_ref] = resolved_base_hash
+                self._ref_hash_cache[self.s.base_ref] = resolved_base_hash
 
         except (GithubException, ValueError, TypeError):
             logger.exception("Failed to resolve commit hashes via GraphQL")
 
-        resolved_head_hash = self._ref_hash_cache.get(head_ref, head_ref)
-        resolved_base_hash = self._ref_hash_cache.get(base_ref, base_ref)
-        if resolved_head_hash == head_ref or resolved_base_hash == base_ref:
+        resolved_head_hash = self._ref_hash_cache.get(self.s.head_ref, self.s.head_ref)
+        resolved_base_hash = self._ref_hash_cache.get(self.s.base_ref, self.s.base_ref)
+        if resolved_head_hash == self.s.head_ref or resolved_base_hash == self.s.base_ref:
             logger.warning("Could not resolve one or more commit hashes, falling back to provided refs")
         return resolved_head_hash, resolved_base_hash
 
@@ -163,12 +167,6 @@ class GithubApi:
             return f"{parsed.scheme}://{parsed.netloc}{graphql_path}"
 
         return f"{self.s.api_url.rstrip('/')}/graphql"
-
-    @staticmethod
-    def _qualified_ref(ref: str) -> str:
-        if ref.startswith("refs/"):
-            return ref
-        return f"refs/heads/{ref}"
 
     def delete_comment(self, comment_id: int) -> None:
         logger.debug("Deleting comment {}", comment_id)

--- a/diff_poetry_lock/github_api.py
+++ b/diff_poetry_lock/github_api.py
@@ -89,7 +89,7 @@ class GithubApi:
 
         all_comments = issue.get_comments()
 
-        logger.debug("Found %d comments", all_comments.totalCount)
+        logger.debug("Found {} comments", all_comments.totalCount)
 
         def is_diff_comment(comment: IssueComment) -> bool:
             return comment.body.startswith(MAGIC_COMMENT_IDENTIFIER)

--- a/diff_poetry_lock/run_poetry.py
+++ b/diff_poetry_lock/run_poetry.py
@@ -143,7 +143,7 @@ def do_diff(settings: Settings) -> None:
     if not any(package.changed() for package in packages):
         summary = None
     else:
-        head_commit_hash, base_commit_hash = api.resolve_commit_hashes(settings.head_ref, settings.base_ref)
+        head_commit_hash, base_commit_hash = api.resolve_commit_hashes()
         summary = format_comment(
             packages,
             base_commit_hash=base_commit_hash,

--- a/diff_poetry_lock/run_poetry.py
+++ b/diff_poetry_lock/run_poetry.py
@@ -8,7 +8,7 @@ from poetry.core.packages.package import Package
 from poetry.packages import Locker
 
 from diff_poetry_lock import __version__
-from diff_poetry_lock.github import GithubApi
+from diff_poetry_lock.github_api import GithubApi
 from diff_poetry_lock.logging_utils import configure_logging
 from diff_poetry_lock.settings import Settings, determine_and_load_settings
 

--- a/diff_poetry_lock/settings.py
+++ b/diff_poetry_lock/settings.py
@@ -30,8 +30,7 @@ class Settings(ABC):
         return any(key.lower() == cls.sigil_envvar.lower() for key in env)
 
     @property
-    # todo: Avoid this MyPy error by having Pydantic compute the field
-    def pr_num(self) -> int | None:  # type: ignore[override]
+    def pr_num(self) -> int | None:
         # TODO: Validate early
         match = re.fullmatch(r"refs/pull/(\d+)/(?:head|merge)", self.ref)
         return int(match.group(1)) if match else None

--- a/diff_poetry_lock/settings.py
+++ b/diff_poetry_lock/settings.py
@@ -1,10 +1,11 @@
 import os
+import re
 import sys
 from abc import ABC
 from typing import Any, ClassVar
 
 from loguru import logger
-from pydantic import BaseSettings, Field, PrivateAttr, ValidationError, validator
+from pydantic import BaseSettings, Field, ValidationError, validator
 
 
 class Settings(ABC):
@@ -30,9 +31,10 @@ class Settings(ABC):
 
     @property
     # todo: Avoid this MyPy error by having Pydantic compute the field
-    def pr_num(self) -> str | None:  # type: ignore[override]
+    def pr_num(self) -> int | None:  # type: ignore[override]
         # TODO: Validate early
-        return self.ref.split("/")[2]
+        match = re.fullmatch(r"refs/pull/(\d+)/(?:head|merge)", self.ref)
+        return int(match.group(1)) if match else None
 
 
 class VelaSettings(BaseSettings, Settings):

--- a/diff_poetry_lock/settings.py
+++ b/diff_poetry_lock/settings.py
@@ -1,19 +1,10 @@
 import os
 import sys
 from abc import ABC
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import Any, ClassVar
 
 from loguru import logger
 from pydantic import BaseSettings, Field, PrivateAttr, ValidationError, validator
-
-
-class PrLookupService(Protocol):
-    def find_pr_for_branch(self, branch_ref: str) -> str: ...
-
-
-@runtime_checkable
-class PrLookupConfigurable(Protocol):
-    def set_pr_lookup_service(self, service: PrLookupService) -> None: ...
 
 
 class Settings(ABC):
@@ -23,7 +14,6 @@ class Settings(ABC):
     head_ref: str
     repository: str
     base_ref: str
-    pr_num: str | None
 
     # from step config including secrets
     token: str
@@ -38,11 +28,15 @@ class Settings(ABC):
         """Check whether this CI's identifying env var is present."""
         return any(key.lower() == cls.sigil_envvar.lower() for key in env)
 
+    @property
+    # todo: Avoid this MyPy error by having Pydantic compute the field
+    def pr_num(self) -> str | None:  # type: ignore[override]
+        # TODO: Validate early
+        return self.ref.split("/")[2]
+
 
 class VelaSettings(BaseSettings, Settings):
     sigil_envvar: ClassVar[str] = "VELA_REPO_FULL_NAME"
-    _pr_lookup_service: PrLookupService | None = PrivateAttr(default=None)
-    _pr_num_cached: str = PrivateAttr(default="")
 
     # from CI
     event_name: str = Field(env="VELA_BUILD_EVENT")
@@ -67,32 +61,9 @@ class VelaSettings(BaseSettings, Settings):
         logger.debug("VelaSettings ref={}", self.ref)
         logger.debug("VelaSettings event_name={}", self.event_name)
 
-    def set_pr_lookup_service(self, service: PrLookupService) -> None:
-        self._pr_lookup_service = service
-
-    @property
-    def pr_num(self) -> str | None:  # type: ignore[override]
-        if self._pr_num_cached:
-            return self._pr_num_cached
-
-        if self._pr_lookup_service is None:
-            logger.warning("PR lookup requested before service configured; returning None")
-            return None
-
-        logger.debug("VelaSettings.pr_num looking up PR for branch {}", self.ref)
-        pr_num = self._pr_lookup_service.find_pr_for_branch(self.ref)
-        self._pr_num_cached = pr_num
-        if pr_num:
-            logger.debug("VelaSettings.pr_num found PR #{}", pr_num)
-        else:
-            logger.warning("VelaSettings.pr_num found no open PR")
-        return pr_num
-
 
 class GitHubActionsSettings(BaseSettings, Settings):
     sigil_envvar: ClassVar[str] = "github_repository"
-    _pr_lookup_service: PrLookupService | None = PrivateAttr(default=None)
-    _pr_num_cached: str = PrivateAttr(default="")
 
     # from CI
     event_name: str = Field(env="github_event_name")  # must be 'pull_request'
@@ -124,12 +95,6 @@ class GitHubActionsSettings(BaseSettings, Settings):
             msg = f"This Github Action can only run in the context of events {allowed_events}."
             raise ValueError(msg)
         return v
-
-    @property
-    # todo: Avoid this MyPy error by having Pydantic compute the field
-    def pr_num(self) -> str | None:  # type: ignore[override]
-        # TODO: Validate early
-        return self.ref.split("/")[2]
 
 
 _CI_SETTINGS_CANDIDATES: list[type[Settings]] = [GitHubActionsSettings, VelaSettings]

--- a/diff_poetry_lock/test/test_poetry_diff.py
+++ b/diff_poetry_lock/test/test_poetry_diff.py
@@ -13,7 +13,6 @@ from diff_poetry_lock.github import MAGIC_COMMENT_IDENTIFIER, GithubApi
 from diff_poetry_lock.run_poetry import PackageSummary, diff, do_diff, format_comment, load_packages, main
 from diff_poetry_lock.settings import (
     GitHubActionsSettings,
-    PrLookupConfigurable,
     Settings,
     VelaSettings,
 )
@@ -37,20 +36,6 @@ def data2() -> bytes:
     return load_file(TESTFILE_2)
 
 
-class _LookupService:
-    def __init__(self, settings: Settings) -> None:
-        self.s = settings
-        if isinstance(self.s, PrLookupConfigurable):
-            self.s.set_pr_lookup_service(self)
-
-    def find_pr_for_branch(self, branch_ref: str) -> str:
-        if branch_ref == "refs/heads/github-actions":
-            return "42"
-        if branch_ref == "refs/heads/vela":
-            return "1"
-        return ""
-
-
 def test_settings(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_REF", "refs/pull/42/merge")
@@ -70,7 +55,7 @@ def test_settings(monkeypatch: MonkeyPatch) -> None:
 
 def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("VELA_BUILD_EVENT", "push")
-    monkeypatch.setenv("VELA_BUILD_REF", "refs/heads/vela")
+    monkeypatch.setenv("VELA_BUILD_REF", "refs/pull/42/merge")
     monkeypatch.setenv("VELA_REPO_FULL_NAME", "account/repo")
     monkeypatch.setenv("VELA_REPO_BRANCH", "main")
     monkeypatch.setenv("PARAMETER_GITHUB_TOKEN", "vela-token")
@@ -79,14 +64,10 @@ def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
 
     s = VelaSettings()
     assert s.event_name == "push"
-    assert s.ref == "refs/heads/vela"
+    assert s.ref == "refs/pull/42/merge"
     assert s.repository == "account/repo"
     assert s.base_ref == "refs/heads/main"
-    assert s.pr_num is None
-
-    _LookupService(s)
-
-    assert s.pr_num == "1"
+    assert s.pr_num == "42"
 
 
 def test_settings_not_pr(monkeypatch: MonkeyPatch) -> None:

--- a/diff_poetry_lock/test/test_poetry_diff.py
+++ b/diff_poetry_lock/test/test_poetry_diff.py
@@ -9,7 +9,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from requests_mock import Mocker
 
 from diff_poetry_lock import __version__
-from diff_poetry_lock.github import MAGIC_COMMENT_IDENTIFIER, GithubApi
+from diff_poetry_lock.github_api import MAGIC_COMMENT_IDENTIFIER, GithubApi
 from diff_poetry_lock.run_poetry import PackageSummary, diff, do_diff, format_comment, load_packages, main
 from diff_poetry_lock.settings import (
     GitHubActionsSettings,
@@ -55,7 +55,7 @@ def test_settings(monkeypatch: MonkeyPatch) -> None:
 
 def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("VELA_BUILD_EVENT", "push")
-    monkeypatch.setenv("VELA_BUILD_REF", "refs/pull/42/merge")
+    monkeypatch.setenv("VELA_BUILD_REF", "refs/pull/42/head")
     monkeypatch.setenv("VELA_REPO_FULL_NAME", "account/repo")
     monkeypatch.setenv("VELA_REPO_BRANCH", "main")
     monkeypatch.setenv("PARAMETER_GITHUB_TOKEN", "vela-token")
@@ -64,7 +64,7 @@ def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
 
     s = VelaSettings()
     assert s.event_name == "push"
-    assert s.ref == "refs/pull/42/merge"
+    assert s.ref == "refs/pull/42/head"
     assert s.repository == "account/repo"
     assert s.base_ref == "refs/heads/main"
     assert s.pr_num == "42"

--- a/diff_poetry_lock/test/test_poetry_diff.py
+++ b/diff_poetry_lock/test/test_poetry_diff.py
@@ -50,7 +50,7 @@ def test_settings(monkeypatch: MonkeyPatch) -> None:
     assert s.head_ref == "use-github-package"
     assert s.repository == "account/repo"
     assert s.base_ref == "main"
-    assert s.pr_num == "42"
+    assert s.pr_num == 42
 
 
 def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
@@ -67,7 +67,7 @@ def test_vela_settings(monkeypatch: MonkeyPatch) -> None:
     assert s.ref == "refs/pull/42/head"
     assert s.repository == "account/repo"
     assert s.base_ref == "refs/heads/main"
-    assert s.pr_num == "42"
+    assert s.pr_num == 42
 
 
 def test_settings_not_pr(monkeypatch: MonkeyPatch) -> None:
@@ -334,8 +334,8 @@ def test_resolve_commit_hash_request_exception_returns_ref(cfg: Settings, monkey
 
     monkeypatch.setattr(api.requester, "graphql_query", raise_timeout)
 
-    resolved_head, resolved_base = api.resolve_commit_hashes(cfg.ref, cfg.base_ref)
-    assert resolved_head == cfg.ref
+    resolved_head, resolved_base = api.resolve_commit_hashes()
+    assert resolved_head == cfg.head_ref
     assert resolved_base == cfg.base_ref
 
 
@@ -344,7 +344,7 @@ def test_resolve_commit_hash_cache_hit_uses_cached_value(cfg: Settings) -> None:
 
     with requests_mock.Mocker() as m:
         mock_resolve_commit_hashes(m, cfg, head_hash="cached-sha", base_hash="base-sha")
-        resolved_head, resolved_base = api.resolve_commit_hashes(cfg.ref, cfg.base_ref)
+        resolved_head, resolved_base = api.resolve_commit_hashes()
 
     assert resolved_head == "cached-sha"
     assert resolved_base == "base-sha"
@@ -355,8 +355,8 @@ def test_resolve_commit_hash_cache_miss_returns_ref(cfg: Settings) -> None:
 
     with requests_mock.Mocker() as m:
         mock_resolve_commit_hashes(m, cfg)
-        resolved_head, resolved_base = api.resolve_commit_hashes(cfg.ref, cfg.base_ref)
-        assert resolved_head == cfg.ref
+        resolved_head, resolved_base = api.resolve_commit_hashes()
+        assert resolved_head == cfg.head_ref
         assert resolved_base == cfg.base_ref
 
 
@@ -414,8 +414,10 @@ def mock_resolve_commit_hashes(
     response_json = {
         "data": {
             "repository": {
-                "head": {"target": {"oid": head_hash}} if head_hash else None,
-                "base": {"target": {"oid": base_hash}} if base_hash else None,
+                "pullRequest": {
+                    "headRefOid": head_hash if head_hash else None,
+                    "baseRefOid": base_hash if base_hash else None,
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
The vela route pr_num lookup was customized when github was hosted on prem but now with the migration to github cloud, the pr_num lookup can be simplified which this pr is for

In addition to that, fixed a couple of minor issues to get the tool working with vela:
- Renamed github.py because of naming collision issue
Error thrown before renaming:
>ImportError: cannot import name 'Auth' from 'github' (consider renaming '/tmp/diff-poetry-lock/diff_poetry_lock/github.py' if it has the same name as a library you intended to import)
- Fixed auth header for get_file github api helper
- Fixed a log that was not resolving the number of comments it found in a pr
- Fixed commit sha resolution; the head ref wasn't getting resolved so updated the graphql lookup to now use the pr_num instead to make it more stable instead of the previously used head and base refs