### PR TITLE
fix: add non-root USER to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ FROM python:3.11-slim@sha256:0b23cfb7425d065008b778022a17b1551c82f8b4866ee5a7a20
 
 WORKDIR /src
 
+RUN useradd --system --shell /usr/sbin/nologin diffpoetrylock
+
 COPY --from=build /src/requirements.txt /tmp/requirements.txt
 COPY --from=build /src/dist/*.whl /tmp/
 RUN pip install --no-cache-dir --requirement /tmp/requirements.txt \
@@ -20,5 +22,9 @@ RUN pip install --no-cache-dir --requirement /tmp/requirements.txt \
 	&& rm -f /tmp/requirements.txt /tmp/*.whl
 
 COPY entrypoint.sh /src/entrypoint.sh
+RUN chmod 0755 /src/entrypoint.sh \
+	&& chown -R diffpoetrylock:diffpoetrylock /src
+
+USER diffpoetrylock
 
 ENTRYPOINT ["/src/entrypoint.sh"]


### PR DESCRIPTION
Closes #68

## What changed

Run the container as a dedicated system user (`diffpoetrylock`) instead of root. This reduces the blast radius of any runtime compromise by removing root-level privileges from the container process.

```dockerfile
RUN useradd --system --shell /usr/sbin/nologin diffpoetrylock
```

- Creates a passwordless system account with no interactive login shell (`/usr/sbin/nologin` prevents interactive access even if the account is somehow targeted).
- `chown -R diffpoetrylock:diffpoetrylock /src` — ensures runtime files are owned by the new user so the process can read/execute them.
- `USER diffpoetrylock` — switches execution to the non-root account for the container's lifetime.

No home directory is created — the runtime path uses `/tmp` for temporary files and `/src` for app files, so no `HOME`-based paths are needed.

## Validation

Built the image locally and confirmed non-root runtime:

```
$ docker run --entrypoint id diff-poetry-lock:test
uid=999(diffpoetrylock) gid=999(diffpoetrylock) groups=999(diffpoetrylock)

$ docker run --entrypoint /bin/sh diff-poetry-lock:test -c 'whoami && ls -l /src/entrypoint.sh'
diffpoetrylock
-rwxr-xr-x 1 diffpoetrylock diffpoetrylock 1042 Jun 26 18:23 /src/entrypoint.sh
```